### PR TITLE
QPoint generation speedup and extend random-extended

### DIFF
--- a/pfmatch/apps/toymc.py
+++ b/pfmatch/apps/toymc.py
@@ -141,7 +141,7 @@ class ToyMC():
                                        is_outside_boundary)
 
             boundary = ((xmin, xmax), (ymin, ymax), (zmin, zmax))
-            tracks = generate_unbounded_tracks(num_tracks, boundary, self.rng)
+            tracks = generate_unbounded_tracks(num_tracks, boundary, extension_factor=0.5, rng=self.rng)
             mask = np.asarray([is_outside_boundary(point, boundary) for point in tracks.reshape(-1, 3)]).reshape(-1, 2)
             one_in = mask.sum(axis=1) == 1
             all_in = mask.sum(axis=1) == 0
@@ -152,7 +152,7 @@ class ToyMC():
                 bad_pt = track[m].squeeze()
                 good_pt = track[~m].squeeze()
                 
-                intersection = segment_intersection_point(boundary, good_pt, bad_pt)
+                intersection = segment_intersection_point(boundary, good_pt, bad_pt)[0]
                 track[m] = intersection.reshape(-1, 3)
                 
             out_tracks = np.vstack([tracks_both_in, tracks_one_in])

--- a/pfmatch/utils/utils.py
+++ b/pfmatch/utils/utils.py
@@ -136,7 +136,7 @@ def generate_unbounded_tracks(N, boundary, extension_factor=0.2, rng=np.random):
     
     return tracks.T
 
-def find_intersection_with_boundary(boundary, point_inside, point_outside):
+def segment_intersection_point(boundary, point_inside, point_outside):
     """
     Given a boundary and two points of a line segment that crosses the boundary of a cube,
     this function finds the intersection point of the line segment with the boundary.
@@ -154,7 +154,7 @@ def find_intersection_with_boundary(boundary, point_inside, point_outside):
     direction = point_inside - point_outside
 
     # Initialize intersection point
-    intersection_point = point_outside
+    intersection_points = []
 
     # Check for intersection with each face of the boundary box
     for i, (min_val, max_val) in enumerate(boundary):
@@ -174,11 +174,12 @@ def find_intersection_with_boundary(boundary, point_inside, point_outside):
             # Check if the intersection point is within the boundary on the other two axes
             if all(min_val <= intersection_test[j] <= max_val for j, (min_val, max_val) in enumerate(boundary) if j != i):
                 intersection_point = intersection_test
-                return intersection_point
+                intersection_points.append(intersection_point)
+                # return intersection_point
 
-    return intersection_point
+    return intersection_points
 
-def is_outside(point, boundary):
+def is_outside_boundary(point, boundary):
     """
     Checks if a point is outside the boundary.
     


### PR DESCRIPTION
This PR does two things:
* speeds up `LightPath.segment_to_qpoints`, which takes line segments and creates a set of charges along the track, by substituting a for loop for several quicker vectorized ops.
* allow for `utils.segment_intersection_point` to find multiple intersection points to the bounding box of the detector active volume instead of just one. Right now, in the `random-extended` algorithm, ToyMC generates a bunch of points in a uniform area greater than the active volume and saves tracks that have at least one point in the active volume. If one of the points is outside the volume, that point is scaled to the intersection point between the track and the active volume boundary. Extending this to tracks where both points are outside the active volume, but at some point intersects through the active volume, would require both intersections to be returned so both endpoints could be scaled to the active volume boundary.