### PR TITLE
Adaption for the previous study of module-0 data.

### DIFF
--- a/pfmatch/__future__/io_factories.py
+++ b/pfmatch/__future__/io_factories.py
@@ -24,7 +24,7 @@ def loader_factory(cfg):
     ds = dataset_factory(cfg)
 
     data_cfg = cfg['data']
-    loader_cfg = data_cfg.get('loader', dict(interface='DataLoader'))
+    loader_cfg = data_cfg.get('loader', dict(interface='DataLoader')).copy()
     loader_type = loader_cfg.pop('interface')
     if loader_type == 'DataLoader':
         loader_cfg['collate_fn']=ds.read_many

--- a/pfmatch/__future__/sopt.py
+++ b/pfmatch/__future__/sopt.py
@@ -6,6 +6,17 @@ from slar.optimizers import get_lr
 from pfmatch.utils import scheduler_factory, CSVLogger
 from pfmatch.algorithms import PoissonMatchLoss
 from pfmatch.__future__.io_factories import loader_factory
+from pfmatch.utils import import_from
+
+def criterion_factory(cfg):
+    crit_cfg = cfg['train'].get('criterion', {}).copy()
+    class_name = crit_cfg.pop('class', None)
+    if class_name is None:
+        return PoissonMatchLoss()
+
+    CritCls = import_from(class_name)
+    crit = CritCls(**crit_cfg)
+    return crit
 
 class SOptimizer:
     def __init__(self, cfg, device=None, resume=True):
@@ -35,7 +46,8 @@ class SOptimizer:
         self._dataloader = loader_factory(cfg)
         self._logger = CSVLogger(cfg)
         
-        self.criterion = PoissonMatchLoss()
+        self.criterion = criterion_factory(cfg)
+        print('[Criterion]', self.criterion)
 
         self.epoch = 0
         self.n_iter = 0
@@ -68,16 +80,12 @@ class SOptimizer:
         else:
             target = batch['flashes']
         
-        #q = qpts[:,-1]
         vis_q = self._model.visibility(qpts[:,:3]) * qpts[:,-1].unsqueeze(-1)    
-    
-        pred = torch.stack([arr.sum(axis=0) for arr in torch.split(vis_q, sizes)])
-        #del vis_q
-        
-        # target pe from flashes
-        weights = torch.zeros_like(target)
-        weights[target>0] = 1.
-        loss = self.criterion(pred, target, weights)
+        pred = torch.stack([
+            arr.sum(axis=0) for arr in torch.split(vis_q, sizes)
+        ])
+
+        loss = self.criterion(pred, target)
         
         return pred, loss
     
@@ -144,7 +152,7 @@ class SOptimizer:
         import os
         fpath = os.path.join(
             self._logger.logdir,
-            f'iteration-{self.n_iter:06}-epoch-{self.epoch:03}.ckpt'
+            f'iteration-{self.n_iter:08}-epoch-{self.epoch:05}.ckpt'
         )
         self._model.save_state(fpath, self._optimizer)
         

--- a/pfmatch/algorithms/__init__.py
+++ b/pfmatch/algorithms/__init__.py
@@ -1,5 +1,5 @@
 from .lightpath import LightPath
 from .hypothesis import FlashHypothesis, MultiFlashHypothesis, PLibPrediction
-from .criterion import PoissonMatchLoss
+from .criterion import PoissonMatchLoss, Chi2Loss
 from .sirentrack import SirenTrack
 

--- a/pfmatch/algorithms/criterion.py
+++ b/pfmatch/algorithms/criterion.py
@@ -14,4 +14,23 @@ class PoissonMatchLoss(torch.nn.Module):
         H = torch.clamp(input, min=0.01)
         O = torch.clamp(target, min=0.01)
         loss = self.poisson_nll(H, O) - torch.log(H) / 2
-        return torch.mean(weight*loss, axis=axis)
+        return torch.nanmean(weight*loss, axis=axis)
+
+class Chi2Loss(torch.nn.Module):
+    '''
+    Chi2 loss w/ additional (constant) error terms.
+    '''
+    def __init__(self, err0=0):
+        super().__init__()
+        self.register_buffer(
+            '_err0', torch.as_tensor(err0, dtype=torch.float32)
+        )
+        
+    def forward(self, input, target):
+        w = 1 / (input + self._err0**2)
+        mask = ~target.isnan()
+        loss = w[mask] * (input[mask] - target[mask])**2
+        return loss.mean()
+
+    def __str__(self):
+        return f'Chi2Loss(err0={self._err0})'


### PR DESCRIPTION
This pull request reproduce the previous study of module-0 data using the latest SOptimizer code. It works (in terms of code execution, not physics performance) with ToyMC tracks and Module-0 data (after converting data format).

Here is an example config:

```
import yaml
cfg = yaml.safe_load('''

data:
  dataset:
    interface: TracksInConsecutiveMemory
    filepath: /sdf/group/neutrino/kvtsang/project/cider-2x2/data/module0/train/*.h5
    n_pmts: 48
    device: cuda
  loader:
    interface: RandomSequenceLoader
    batch_size: 8192
    concat: True
    drop_last: True
    #terminate: False

train:
  optimizer:
    lr: 5.e-5
  save_every_iterations: 200
  max_epochs: 10000
  criterion:
    class: pfmatch.algorithms.Chi2Loss
    err0: 5.

photonlib:
  filepath: /sdf/group/neutrino/kvtsang/project/cider-2x2/data/module0/plib_highres_rescaled.h5

model:
  network:
    in_features: 3
    hidden_features: 128
    hidden_layers: 1
    out_features: 48
    outermost_linear: True
  ckpt_file: ""
  output_scale:
    fix: False
    init: /sdf/group/neutrino/kvtsang/project/cider-2x2/data/module0/light_yield_eff.npy
  hardsigmoid: True

transform_vis:
  eps: 1.0e-4
  vmax: 1.0

logger:
  dir_name: logs
  file_name: log.csv
  log_every_nsteps: 10
''')

from pfmatch.__future__ import SOptimizer
sopt = SOptimizer(cfg, device=0)
sopt.train()

```